### PR TITLE
MonadRandom monad support

### DIFF
--- a/simple-genetic-algorithm.cabal
+++ b/simple-genetic-algorithm.cabal
@@ -2,7 +2,7 @@
 -- further documentation, see http://haskell.org/cabal/users-guide/
 
 name:                simple-genetic-algorithm
-version:             0.2.1.0
+version:             0.3.0.0
 synopsis:            Simple parallel genetic algorithm implementation
 description:         Simple parallel genetic algorithm implementation
 homepage:            http://eax.me/haskell-genetic-algorithm/
@@ -14,7 +14,7 @@ maintainer:          mail@eax.me
 category:            AI
 build-type:          Simple
 -- extra-source-files:  
-cabal-version:       >=1.10
+cabal-version:       >= 1.10
 
 source-repository head
     type:     git
@@ -23,9 +23,12 @@ source-repository head
 library
   exposed-modules:     AI.GeneticAlgorithm.Simple
   ghc-options:         -O2 -Wall -fno-warn-missing-signatures
-  build-depends:       base >=4.5 && < 4.8,
+  build-depends:       
+                       base >=4.5 && < 4.8,
                        random >= 1.0 && < 1.2,
-                       parallel >= 3.2 && < 3.3
+                       parallel >= 3.2 && < 3.3,
+                       MonadRandom >=0.2 && < 0.4,
+                       transformers >= 0.4
   hs-source-dirs:      src
   default-language:    Haskell2010
 
@@ -35,7 +38,9 @@ executable ga-sin-example
   build-depends:       base >= 4.5 && < 4.8,
                        random >= 1.0 && < 1.2,
                        deepseq >= 1.3 && < 1.4,
-                       parallel >= 3.2 && < 3.3
+                       parallel >= 3.2 && < 3.3,
+                       MonadRandom >=0.2 && < 0.4,
+                       transformers >= 0.4
   hs-source-dirs:      src
   default-language:    Haskell2010
 

--- a/src/AI/GeneticAlgorithm/Simple.hs
+++ b/src/AI/GeneticAlgorithm/Simple.hs
@@ -26,25 +26,22 @@
 -- >     in maximum [ abs $ sin x - f x | x <- [0.0,0.001 .. pi/2]]
 -- > 
 -- > instance Chromosome SinInt where
--- >     crossover g (SinInt xs) (SinInt ys) =
--- >         ( [ SinInt (L.zipWith (\x y -> (x+y)/2) xs ys) ], g)
--- > 
--- >     mutation g (SinInt xs) =
--- >         let (idx, g') = randomR (0, length xs - 1) g
--- >             (dx, g'') = randomR (-10.0, 10.0) g'
--- >             t = xs !! idx
--- >             xs' = take idx xs ++ [t + t*dx] ++ drop (idx+1) xs
--- >         in (SinInt xs', g'')
+-- >    crossover (SinInt xs) (SinInt ys) =
+-- >        return [ SinInt (L.zipWith (\x y -> (x+y)/2) xs ys) ]
+-- >
+-- >    mutation (SinInt xs) = do
+-- >        idx <- getRandomR (0, length xs - 1)
+-- >        dx  <- getRandomR (-10.0, 10.0)
+-- >        let t = xs !! idx
+-- >            xs' = take idx xs ++ [t + t*dx] ++ drop (idx+1) xs
+-- >        return $ SinInt xs'
 -- > 
 -- >     fitness int =
 -- >         let max_err = 1000.0 in
 -- >         max_err - (min (err int) max_err)
 -- > 
 -- > randomSinInt gen = 
--- >     let (lst, gen') =
--- >             L.foldl'
--- >                 (\(xs, g) _ -> let (x, g') = randomR (-10.0,10.0) g in (x:xs,g') )
--- >                 ([], gen) [0..polynomialOrder]
+-- >     lst <- replicateM polynomialOrder (getRandomR (-10.0,10.0))
 -- >     in (SinInt lst, gen')
 -- > 
 -- > stopf :: SinInt -> Int -> IO Bool
@@ -70,94 +67,103 @@ import System.Random
 import qualified Data.List as L
 import Control.Parallel.Strategies
 
+import Control.Monad.Random
+import Control.Monad
+import Control.Monad.IO.Class (liftIO)
+
+
 -- | Chromosome interface
 class NFData a => Chromosome a where
     -- | Crossover function
-    crossover :: RandomGen g => g -> a -> a -> ([a],g)
+    crossover :: RandomGen g => a -> a -> Rand g [a]
     -- | Mutation function
-    mutation :: RandomGen g => g -> a -> (a,g)
+    mutation :: RandomGen g => a -> Rand g a
     -- | Fitness function. fitness x > fitness y means that x is better than y 
     fitness :: a -> Double
+
+
 
 -- | Pure GA implementation.
 runGA   :: (RandomGen g, Chromosome a)
         => g                        -- ^ Random number generator
         -> Int                      -- ^ Population size
         -> Double                   -- ^ Mutation probability [0, 1]
-        -> (g -> (a, g))            -- ^ Random chromosome generator (hint: use currying or closures)
+        -> Rand g a                 -- ^ Random chromosome generator (hint: use currying or closures)
         -> (a -> Int -> Bool)       -- ^ Stopping criteria, 1st arg - best chromosome, 2nd arg - generation number
         -> a                        -- ^ Best chromosome
-runGA gen ps mp rnd stopf =
-    let (pop, gen') = zeroGeneration gen rnd ps in
-    runGA' gen' pop ps mp stopf 0
+runGA gen ps mp rnd stopf = evalRand go gen
+  where 
+    go = do
+      pop <- zeroGeneration rnd ps
+      runGA' pop ps mp stopf 0
 
-runGA' gen pop ps mp stopf gnum =
-    let best = head pop in
+runGA' pop ps mp stopf gnum = do
+    let best = head pop
     if stopf best gnum
-        then best
-        else
-            let (pop', gen') = nextGeneration gen pop ps mp in
-            runGA' gen' pop' ps mp stopf (gnum+1)
+        then return best
+        else do
+            pop' <- nextGeneration pop ps mp
+            runGA' pop' ps mp stopf (gnum+1)
 
 -- | Non-pure GA implementation.
 runGAIO :: Chromosome a
         => Int                      -- ^ Population size
         -> Double                   -- ^ Mutation probability [0, 1]
-        -> (StdGen -> (a, StdGen))  -- ^ Random chromosome generator (hint: use currying or closures)
+        -> RandT StdGen IO a        -- ^ Random chromosome generator (hint: use currying or closures)
         -> (a -> Int -> IO Bool)    -- ^ Stopping criteria, 1st arg - best chromosome, 2nd arg - generation number
         -> IO a                     -- ^ Best chromosome
 runGAIO ps mp rnd stopf = do
-    gen <- newStdGen
-    let (pop, gen') = zeroGeneration gen rnd ps
-    runGAIO' gen' pop ps mp stopf 0
+  gen <- getStdGen
+  evalRandT go gen
+  where
+    go = do
+      pop <- zeroGeneration rnd ps
+      runGAIO' pop ps mp stopf 0
 
-runGAIO' gen pop ps mp stopf gnum = do
+runGAIO' :: (RandomGen g, Chromosome a) => [a]  -> Int -> Double -> (a -> Int -> IO Bool) -> Int -> RandT g IO a
+runGAIO' pop ps mp stopf gnum = do
     let best = head pop
-    stop <- stopf best gnum
+    stop <- liftIO $ stopf best gnum
     if stop
         then return best
         else do
-            let (pop', gen') = nextGeneration gen pop ps mp
-            runGAIO' gen' pop' ps mp stopf (gnum+1)
+            pop' <- nextGeneration pop ps mp
+            runGAIO' pop' ps mp stopf (gnum+1)
 
 -- | Generate zero generation. Use this function only if you are going to implement your own runGA.
-zeroGeneration  :: (RandomGen g)
-                => g                -- ^ Random number generator
-                -> (g -> (a, g))    -- ^ Random chromosome generator (hint: use closures)
+zeroGeneration  :: (Monad m,RandomGen g)
+                => RandT g m a         -- ^ Random chromosome generator (hint: use closures)
                 -> Int              -- ^ Population size
-                -> ([a],g)          -- ^ Zero generation and new RNG
-zeroGeneration initGen rnd ps =
-    L.foldl'
-        (\(xs,gen) _ -> let (c, gen') = rnd gen in ((c:xs),gen'))
-        ([], initGen) [1..ps]
+                -> RandT g m [a]       -- ^ Zero generation and new RNG
+zeroGeneration rnd ps =
+    replicateM ps rnd
 
 -- | Generate next generation (in parallel) using mutation and crossover.
 --   Use this function only if you are going to implement your own runGA.
-nextGeneration  :: (RandomGen g, Chromosome a)
-                => g                -- ^ Random number generator
-                -> [a]              -- ^ Current generation
+nextGeneration  :: (Monad m,RandomGen g, Chromosome a)
+                => [a]              -- ^ Current generation
                 -> Int              -- ^ Population size
                 -> Double           -- ^ Mutation probability
-                -> ([a], g)         -- ^ Next generation ordered by fitness (best - first) and new RNG
-nextGeneration gen pop ps mp =
-    let (gen':gens) = L.unfoldr (Just . split) gen
+                -> RandT g m [a]             -- ^ Next generation ordered by fitness (best - first) and new RNG
+nextGeneration pop ps mp = do
+    gen <- getSplit
+    let gens = L.unfoldr (Just . split) gen
         chunks = L.zip gens $ init $ L.tails pop
-        results = map (\(g, (x:ys)) -> [ (t, fitness t) | t <- nextGeneration' [ (x, y) | y <- ys ] g mp [] ]) chunks
+        results = map (\(g, x : ys) -> [ (t, fitness t) | t <- evalRand (nextGeneration' [ (x, y) | y <- ys ] mp []) g ]) chunks
                     `using` parList rdeepseq
         lst = take ps $ L.sortBy (\(_, fx) (_, fy) -> fy `compare` fx) $ concat results
-    in ( map fst lst, gen' )
+    return $ map fst lst
 
-nextGeneration' [] _ _ acc = acc
-nextGeneration' ((p1,p2):ps) g0 mp acc =
-    let (children0, g1) = crossover g0 p1 p2
-        (children1, g2) = L.foldl'
-                             (\(xs, g) x -> let (x', g') = mutate g x mp in (x':xs, g'))
-                             ([],g1) children0
-    in
-    nextGeneration' ps g2 mp (children1 ++ acc)
+nextGeneration' [] _ acc = return acc
+nextGeneration' ((p1,p2):ps) mp acc = do
+    children0 <- crossover p1 p2
+    children1 <- foldM
+                             (\xs x -> mutate x mp >>= (\x'->return (x':xs)))
+                             [] children0
+    nextGeneration' ps mp (children1 ++ acc)
 
-mutate :: (RandomGen g, Chromosome a) => g -> a -> Double -> (a, g)
-mutate gen x mp =
-    let (r, gen') = randomR (0.0, 1.0) gen in
-    if r <= mp  then mutation gen' x
-                else (x, gen')
+mutate :: (RandomGen g, Chromosome a) => a -> Double -> Rand g a
+mutate x mp = do
+    r <- getRandomR (0.0, 1.0)
+    if r <= mp  then mutation x
+                else return x

--- a/src/AI/GeneticAlgorithm/Simple.hs
+++ b/src/AI/GeneticAlgorithm/Simple.hs
@@ -133,8 +133,8 @@ runGAIO' pop ps mp stopf gnum = do
 -- | Generate zero generation. Use this function only if you are going to implement your own runGA.
 zeroGeneration  :: (Monad m,RandomGen g)
                 => RandT g m a         -- ^ Random chromosome generator (hint: use closures)
-                -> Int              -- ^ Population size
-                -> RandT g m [a]       -- ^ Zero generation and new RNG
+                -> Int                 -- ^ Population size
+                -> RandT g m [a]       -- ^ Zero generation 
 zeroGeneration rnd ps =
     replicateM ps rnd
 
@@ -144,7 +144,7 @@ nextGeneration  :: (Monad m,RandomGen g, Chromosome a)
                 => [a]              -- ^ Current generation
                 -> Int              -- ^ Population size
                 -> Double           -- ^ Mutation probability
-                -> RandT g m [a]             -- ^ Next generation ordered by fitness (best - first) and new RNG
+                -> RandT g m [a]    -- ^ Next generation ordered by fitness (best - first)
 nextGeneration pop ps mp = do
     gen <- getSplit
     let gens = L.unfoldr (Just . split) gen
@@ -157,9 +157,7 @@ nextGeneration pop ps mp = do
 nextGeneration' [] _ acc = return acc
 nextGeneration' ((p1,p2):ps) mp acc = do
     children0 <- crossover p1 p2
-    children1 <- foldM
-                             (\xs x -> mutate x mp >>= (\x'->return (x':xs)))
-                             [] children0
+    children1 <- mapM (`mutate` mp) children0
     nextGeneration' ps mp (children1 ++ acc)
 
 mutate :: (RandomGen g, Chromosome a) => a -> Double -> Rand g a


### PR DESCRIPTION
Hello, I don't know if you'll agree, but here goes. This changes your code from pure functions to Rand and RandT functions, which basically means we're using the MonadRandom monad to thread the random generator. This saves the user of the library to have to return the new generator, which makes the client code easier to write. The downside is that there are more dependencies on other libraries and maybe the code is more intimidating to new Haskell users. I've checked and the parallelism is not impacted (all cores are used when running with +RTS -N).